### PR TITLE
appended netstat command for MacOS specific route tables

### DIFF
--- a/f5vpn-login.py
+++ b/f5vpn-login.py
@@ -927,7 +927,7 @@ Cookie: MRHSession=%s\r
         # the default route.
         tunnel_ip = ssl_socket.getpeername()[0]
 
-        default_route = os.popen("netstat -rn | grep '^0\.0\.0\.0' | head -n1").read().split()
+        default_route = os.popen("netstat -rn | grep '^0\.0\.0\.0\|^default' | head -n1").read().split()
         gw_ip = default_route[1]
         default_interface = default_route[-1]
         sys.stderr.write("Detected current default route: %r\n" % gw_ip)


### PR DESCRIPTION
Tried to run this tool for MacOS, but netstat command was not able to find default_route (0.0.0.0)
equivalent on my system was "default"